### PR TITLE
Stefan/increase max requests per host

### DIFF
--- a/autorest/src/main/java/com/microsoft/embeddedsocial/autorest/EmbeddedSocialBatchedClientImpl.java
+++ b/autorest/src/main/java/com/microsoft/embeddedsocial/autorest/EmbeddedSocialBatchedClientImpl.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 
+import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -52,9 +53,13 @@ public final class EmbeddedSocialBatchedClientImpl {
 
         // Create an okhttp3 client with our own batched interceptor. This interceptor
         // allows us to block the outgoing call and queue it for later batching.
+        // We also increase the default maxRequestsPerHost to 32 (our limit to the size of a batch)
         BatchedInterceptor batchedInterceptor = new BatchedInterceptor(this);
-        OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder();
-        okHttpClientBuilder.addInterceptor(batchedInterceptor);
+        Dispatcher dispatcher = new Dispatcher();
+        dispatcher.setMaxRequestsPerHost(32);
+        OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
+                .dispatcher(dispatcher)
+                .addInterceptor(batchedInterceptor);
 
         Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
                 .baseUrl(ESUrl)

--- a/autorest/src/main/java/com/microsoft/embeddedsocial/autorest/EmbeddedSocialBatchedClientImpl.java
+++ b/autorest/src/main/java/com/microsoft/embeddedsocial/autorest/EmbeddedSocialBatchedClientImpl.java
@@ -188,10 +188,10 @@ public final class EmbeddedSocialBatchedClientImpl {
             return this;
         }
 
-        public EmbeddedSocialBatchedClientImpl build() {
-            if (baseUrl == null) new IllegalStateException("ESUrl == null");
-            if (batchSize <= 0) new IllegalStateException("batchSize <= 0");
-            if (batchSize > 32) new IllegalStateException("batchSize cannot be greater than 32.");
+        public EmbeddedSocialBatchedClientImpl build() throws IllegalStateException {
+            if (baseUrl == null) throw new IllegalStateException("ESUrl == null");
+            if (batchSize <= 0) throw new IllegalStateException("batchSize <= 0");
+            if (batchSize > 32) throw new IllegalStateException("batchSize cannot be greater than 32.");
             return new EmbeddedSocialBatchedClientImpl(baseUrl, batchSize);
         }
     }

--- a/autorest/src/main/java/com/microsoft/embeddedsocial/autorest/EmbeddedSocialBatchedClientImpl.java
+++ b/autorest/src/main/java/com/microsoft/embeddedsocial/autorest/EmbeddedSocialBatchedClientImpl.java
@@ -186,6 +186,7 @@ public final class EmbeddedSocialBatchedClientImpl {
         public EmbeddedSocialBatchedClientImpl build() {
             if (baseUrl == null) new IllegalStateException("ESUrl == null");
             if (batchSize <= 0) new IllegalStateException("batchSize <= 0");
+            if (batchSize > 32) new IllegalStateException("batchSize cannot be greater than 32.");
             return new EmbeddedSocialBatchedClientImpl(baseUrl, batchSize);
         }
     }

--- a/test/src/main/java/com/microsoft/test/embeddedsocial/Main.java
+++ b/test/src/main/java/com/microsoft/test/embeddedsocial/Main.java
@@ -7,7 +7,7 @@ package com.microsoft.test.embeddedsocial;
 
 public class Main {
     // Url to Embedded Social instance (use PPE for this example)
-    private final static String ESUrl = "https://api.embeddedsocial.microsoft.com";
+    private final static String ESUrl = "https://ppe.embeddedsocial.microsoft.com";
 
     public static void main(String[] args) {
         SyncTest syncTest = new SyncTest(ESUrl);


### PR DESCRIPTION
This PR increases the batch size to 32. This is done by increasing the `maxRequestsPerHost` of the dispatcher of the `okhttp3` client to 32.

This PR has been tested with batch sizes from 1 to 32. They all worked. I also tested with a batch size of 33 (didn't work).