### PR TITLE
Add check for batch call success before parsing the response

### DIFF
--- a/autorest/src/main/java/com/microsoft/embeddedsocial/autorest/EmbeddedSocialBatchedClientImpl.java
+++ b/autorest/src/main/java/com/microsoft/embeddedsocial/autorest/EmbeddedSocialBatchedClientImpl.java
@@ -157,6 +157,9 @@ public final class EmbeddedSocialBatchedClientImpl {
         okhttp3.Call call = batchClient.newCall(batchReq);
 
         Response batchResponse = call.execute();
+        if (!batchResponse.isSuccessful()) {
+            throw new IOException("Batch request failed with code " + batchResponse.code());
+        }
         processBatchResponse(batchResponse);
 
         // Notify the individual interceptors to resume


### PR DESCRIPTION
A bug still exists, in that none of the registered clients will ever continue (because notify() is never called).

Alternatively, one can invoke notify() prior to throwing the exception and handle the absence of a response in addRequestToBatch().